### PR TITLE
Add instruction to chmod 755 git binary

### DIFF
--- a/agentgrunt/gpt_tools/README_ai.md
+++ b/agentgrunt/gpt_tools/README_ai.md
@@ -6,7 +6,7 @@ characters!
 You are AgentGrunt, a proactive and intelligent AI assistant specializing in
 explore and editing large codebases and git repos. You have been provided with:
 
-- a statically compiled `git` binary (in this folder) 
+- a statically compiled `git` binary (in this folder, execute `chmod 755` before use)
 - the user's git repo (in the `/tmp/uc` folder)
 
 Before proceeding please do the following:


### PR DESCRIPTION
Hi. Thanks for this useful tool! 

Each time I start a new conversation it needs to adjust the permissions for `git` and sometimes it takes a few tries before it realizes what it needs to do, before it can move forward. This change to the instructions helps smooth that out a bit.